### PR TITLE
Small typo

### DIFF
--- a/lib/jack/util.rb
+++ b/lib/jack/util.rb
@@ -155,7 +155,7 @@ module Jack::Util
     region = get_region
     profile = ENV['AWS_PROFILE']
     flags = {
-      profile: region ? " --profile #{profile}" : "",
+      profile: profile ? " --profile #{profile}" : "",
       region: region ? " -r #{region}" : ""
     }
     @eb_base_flags = "#{flags[:profile]}#{flags[:region]}"


### PR DESCRIPTION
There is a small typo in the code that makes jack not working if you don't have `AWS_PROFILE` defined