### PR TITLE
fix yaml formatter sort

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -6,9 +6,10 @@
                     <div class="footer-col col-md-4">
                         <h3>More Tools</h3>
                         <ul class="list-unstyled tools">
-                            <li><a href="http://sonic-screwdriver.cloud">Sonic Screwdriver</a></li>
-                            <li><a href="http://lono.cloud">Lono</a></li>
+                            <li><a href="http://rubyonjets.com">Jets</a></li>
                             <li><a href="http://ufoships.com">Ufo</a></li>
+                            <li><a href="http://lono.cloud">Lono</a></li>
+                            <li><a href="http://sonic-screwdriver.cloud">Sonic</a></li>
                             <li><a href="https://boltops.com/toolbelt">Toolbelt</a></li>
                         </ul>
                     </div>

--- a/lib/jack/config/yaml_formatter.rb
+++ b/lib/jack/config/yaml_formatter.rb
@@ -9,6 +9,7 @@ module Jack
     class YamlFormatter
       def process(file)
         data = YAML.load_file(file)
+        data = sort_top_level_keys(data)
         data = strip_metadata_dates(data)
         dump = YAML.dump(data).gsub("!ruby/object:Hash", '')
         lines = dump.split("\n")
@@ -26,6 +27,13 @@ module Jack
           metadata.delete('DateCreated')
         end
         data
+      end
+
+      def sort_top_level_keys(data)
+        data.keys.sort.inject({}) do |result, k|
+          result[k] = data[k]
+          result
+        end
       end
     end
   end

--- a/spec/lib/config/yaml_formatter_spec.rb
+++ b/spec/lib/config/yaml_formatter_spec.rb
@@ -27,11 +27,11 @@ EOL
 
     it "process should strip date modified and created" do
       input = <<-EOL
+AWSConfigurationTemplateVersion: 1.1.0.0
 EnvironmentConfigurationMetadata:
   DateModified: '1425215243000'
   Description: test.
   DateCreated: '1425215243000'
-AWSConfigurationTemplateVersion: 1.1.0.0
 EOL
       file = "spec/fixtures/fake.cfg.yml"
 


### PR DESCRIPTION
looks like new versions of ruby or yaml or hash doesnt sort the keys
on a YAML.dump anymore, so we need to sort the keys ourselves